### PR TITLE
feat: trigger service controller on tunnel creation

### DIFF
--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -124,7 +124,7 @@ func createTunnelIngress(tunnelName, hostName string, service corev1.Service, po
 		Spec: v1.TunnelIngressSpec{
 			TunnelConfigIngress: v1.TunnelConfigIngress{
 				Hostname: &hostName,
-				Service:  fmt.Sprintf("%s.%s.svc.cluster.local:%s", service.Name, service.Namespace, portStr),
+				Service:  fmt.Sprintf("http://%s.%s.svc.cluster.local:%s", service.Name, service.Namespace, portStr),
 			},
 			TunnelRef: v1.TunnelRef{
 				Kind: v1.TunnelKindTunnel,

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -19,13 +19,15 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
+
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**변경 내역**
- 터널 생성 시 이미 해당 터널을 대상으로 서비스를 생성했을 경우 해당 서비스 찾아 TunnelIngress 생성되도록 수정하였습니다.
-  터널 인그레스 생성 메서드에서(createTunnelIngress 메서드) spec.service에 http 스킴 추가하였습니다.
- Reconcile 메서드에 터널 인그레스 이미 존재 여부에 다른 Create, Update 분기 추가 하였습니다.
- SetControllerReference 설정은 서비스 -> 터널 인그레스, 터널 -> 터널 인그레스 이렇게 줬었는데 Already Owned Error가 발생해서, 터널 -> 터널 인그레스 오너 설정만 남겨두었습니다!
<img width="1377" alt="Screenshot 2024-06-20 at 10 20 29 AM" src="https://github.com/isac322/cloudflared-operator/assets/77036027/46d0ca7d-b17a-4c02-9cd1-49ede03fb15d">


**Changes**
- Modified to create TunnelIngress when a tunnel is created and there is already a service for that tunnel
- Added HTTP scheme to spec.service in the createTunnelIngress method
- Added conditional logic to Reconcile method for creating or updating TunnelIngress based on its existence
- SetControllerReference was initially set for both Service -> TunnelIngress and Tunnel -> TunnelIngress, but an Already Owned Error occurred. So, I left only the Tunnel -> TunnelIngress owner setting.
<img width="1377" alt="Screenshot 2024-06-20 at 10 20 29 AM" src="https://github.com/isac322/cloudflared-operator/assets/77036027/46d0ca7d-b17a-4c02-9cd1-49ede03fb15d">